### PR TITLE
Bump version to fix git tagging issue

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ name: gitlab
 description: GitLab Rest API
 keywords:
     - gitlab
-version: 0.5.2
+version: 0.5.3
 author: Daniel Chamot
 email: daniel@nullkarma.com


### PR DESCRIPTION
Due to an issue with our deployment script, it has tagged the wrong commit. Bumping the version here to get the right set of commits tagged as latest release.