### PR TITLE
Bump pack ver to include changes in master (Python Compatibility fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.5
+
+  - Bump pack version 0.5.4 -> 0.5.5 to include changes in master not reflected in current version (Python 2.7/3.x compatibility)
+
 ## v0.5.2
 
   - Added new action: issue.info

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,10 +1,9 @@
 ---
-
 name: gitlab
 description: GitLab Rest API
 keywords:
   - gitlab
-version: 0.5.4
+version: 0.5.5
 author: Daniel Chamot
 email: daniel@nullkarma.com
 python_versions:


### PR DESCRIPTION
Critical compatibility changes present in ./actions/lib/gitlab.py in master that are not in the current version.

### 0.5.4
```python
from urllib import quote_plus
```

### Master
```python
try:
    from urllib.parse import quote_plus
    import urllib3
    urllib3.disable_warnings()
except ImportError:
    from urllib import quote_plus
```

### Error Observed leading to this
```
  File \"/opt/stackstorm/packs/gitlab/actions/lib/gitlab.py\", line 1, in <module>
    from urllib import quote_plus
ImportError: cannot import name 'quote_plus'
```
##### Full Error

```json
{
  "stdout": "",
  "stderr": "Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 237, in _get_action_instance
    actions_cls = action_loader.register_plugin(Action, self._file_path)
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/loader.py\", line 167, in register_plugin
    module = imp.load_source(module_name, plugin_abs_file_path)
  File \"/usr/lib/python3.6/imp.py\", line 172, in load_source
    module = _load(spec)
  File \"<frozen importlib._bootstrap>\", line 684, in _load
  File \"<frozen importlib._bootstrap>\", line 665, in _load_unlocked
  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module
  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed
  File \"/opt/stackstorm/packs/gitlab/actions/issue_info.py\", line 3, in <module>
    from lib.gitlab import GitlabIssuesAPI
  File \"/opt/stackstorm/packs/gitlab/actions/lib/gitlab.py\", line 1, in <module>
    from urllib import quote_plus
ImportError: cannot import name 'quote_plus'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 333, in <module>
    obj.run()
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 191, in run
    action = self._get_action_instance()
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 244, in _get_action_instance
    raise exc_cls(msg)
ImportError: Failed to load action class from file \"/opt/stackstorm/packs/gitlab/actions/issue_info.py\" (action file most likely doesn't exist or contains invalid syntax): cannot import name 'quote_plus'

Traceback (most recent call last):
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/python_runner/python_action_wrapper.py\", line 237, in _get_action_instance
    actions_cls = action_loader.register_plugin(Action, self._file_path)
  File \"/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/loader.py\", line 167, in register_plugin
    module = imp.load_source(module_name, plugin_abs_file_path)
  File \"/usr/lib/python3.6/imp.py\", line 172, in load_source
    module = _load(spec)
  File \"<frozen importlib._bootstrap>\", line 684, in _load
  File \"<frozen importlib._bootstrap>\", line 665, in _load_unlocked
  File \"<frozen importlib._bootstrap_external>\", line 678, in exec_module
  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed
  File \"/opt/stackstorm/packs/gitlab/actions/issue_info.py\", line 3, in <module>
    from lib.gitlab import GitlabIssuesAPI
  File \"/opt/stackstorm/packs/gitlab/actions/lib/gitlab.py\", line 1, in <module>
    from urllib import quote_plus
ImportError: cannot import name 'quote_plus'

",
  "exit_code": 1,
  "result": "None"
}
```
